### PR TITLE
build: remove libvdeplug.h requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(CheckIncludeFile)
 include(CheckSymbolExists)
 
 set(LIBS_REQUIRED slirp pthread)
-set(HEADERS_REQUIRED libvdeplug.h slirp/libslirp.h)
+set(HEADERS_REQUIRED slirp/libslirp.h)
 set(CMAKE_REQUIRED_QUIET TRUE)
 set(CMAKE_REQUIRED_LIBRARIES slirp)
 


### PR DESCRIPTION
Libvdeplug is not mentioned as a dependency in readme, and
libvdeplug.h is not used in sources.
Remove it from cmake checks to avoid build problems.