### PR TITLE
Use apostrophe

### DIFF
--- a/man/libvdeslirp.3
+++ b/man/libvdeslirp.3
@@ -76,7 +76,7 @@ typedef struct SlirpConfig {
     /* Prohibit connecting to 127\.0\.0\.1:* */
     bool disable_host_loopback;
     /*
-     * Enable emulation code (*warning*: this code isn\'t safe, it is not
+     * Enable emulation code (*warning*: this code isn't safe, it is not
      * recommended to enable it)
      */
     bool enable_emu;


### PR DESCRIPTION
Use apostrophe:

I: libvdeslirp0: acute-accent-in-manual-page usr/share/man/man3/libvdeslirp.3.gz:79

https://lintian.debian.org/tags/acute-accent-in-manual-page.html