### PR TITLE
Use CMake _FULL_ variables.

### DIFF
--- a/vdeslirp.pc.in
+++ b/vdeslirp.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix="${prefix}/@CMAKE_INSTALL_BINDIR@"
-libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
-includedir="${prefix}/@CMAKE_INSTALL_INCLUDEDIR@"
+exec_prefix="@CMAKE_INSTALL_FULL_BINDIR@"
+libdir="@CMAKE_INSTALL_FULL_LIBDIR@"
+includedir="@CMAKE_INSTALL_FULL_INCLUDEDIR@"
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@


### PR DESCRIPTION
This fixes getting two copies of the absolute path in the .pc file when e.g. CMAKE_INSTALL_LIBDIR is an absolute path.